### PR TITLE
Propogate task dependencies from JRubyStorm to its children tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'com.jfrog.bintray'
 apply from: 'gradle/integration-test.gradle'
 
 group = 'com.github.jruby-gradle'
-version = '0.4.2'
+version = '0.4.3'
 defaultTasks 'check', 'assemble'
 
 // Any time we're not expicitly saying "build me a release build" we'll change

--- a/src/main/groovy/com/github/jrubygradle/storm/JRubyStorm.groovy
+++ b/src/main/groovy/com/github/jrubygradle/storm/JRubyStorm.groovy
@@ -37,6 +37,18 @@ class JRubyStorm extends DefaultTask {
         return assembleTask
     }
 
+    /**
+     *  Apply a task dependency to this task and its child tasks
+     *
+     * @param dependencies
+     * @return this task
+     */
+    Task dependsOn(Object... dependencies) {
+        assembleTask?.dependsOn(dependencies)
+        runTask?.dependsOn(dependencies)
+        return super.dependsOn(dependencies)
+    }
+
     /** Path (absolute or relative) to the Ruby file containing the topology */
     @Input
     String topology
@@ -77,7 +89,7 @@ class JRubyStorm extends DefaultTask {
         runTask = JRubyStormInternal.createRunTask(this.project, this)
         assembleTask = JRubyStormInternal.createAssembleTask(this.project, this)
 
-        dependsOn assembleTask
+        super.dependsOn(assembleTask)
         group JRubyPlugin.TASK_GROUP_NAME
 
         project.afterEvaluate { this.updateDependencies() }

--- a/src/test/groovy/com/github/jrubygradle/storm/JRubyStormSpec.groovy
+++ b/src/test/groovy/com/github/jrubygradle/storm/JRubyStormSpec.groovy
@@ -151,6 +151,20 @@ class JRubyStormSpec extends Specification {
         expect:
         task.assembleTask.group == task.group
     }
+
+    @Issue('https://github.com/jruby-gradle/jruby-gradle-storm-plugin/issues/31')
+    def "assemble task should depend on whatever the parent dependsOn"() {
+        given:
+        JRubyStorm task = project.task('spock', type: JRubyStorm)
+        Task otherTask = project.task('dependentTask')
+
+        when:
+        task.dependsOn otherTask
+
+        then:
+        task.dependsOn.contains(otherTask)
+        task.assembleTask.dependsOn.contains(otherTask)
+    }
 }
 
 @Ignore("For some reason these are running with DEBUG log level and it won't turn off")


### PR DESCRIPTION
Fixes #31